### PR TITLE
Adding kubeconfig merge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@
     source ./build-run-app.sh
     ``` 
     Tip: Ensure you run this command from the source repository's root folder.
+3. Select an Azure Dev Spaces controller. 
 
+    ```
+    az aks use-dev-spaces --name bikesharing01 --resource-group bikesharing01 
+    ```
 3. Open the web frontend in a browser (the previous script displays the webapp's url, or run `azds list-uris`). Sign into the web app using one of the sample customer accounts, as defined in the file [PopulateDatabase/data.json](PopulateDatabase/data.json).
 
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,7 @@
     source ./build-run-app.sh
     ``` 
     Tip: Ensure you run this command from the source repository's root folder.
-3. Select an Azure Dev Spaces controller. 
 
-    ```
-    az aks use-dev-spaces --name bikesharing01 --resource-group bikesharing01 
-    ```
 3. Open the web frontend in a browser (the previous script displays the webapp's url, or run `azds list-uris`). Sign into the web app using one of the sample customer accounts, as defined in the file [PopulateDatabase/data.json](PopulateDatabase/data.json).
 
 

--- a/create-aks.sh
+++ b/create-aks.sh
@@ -24,7 +24,10 @@ az group create --name $AKS_NAME --location $AKS_REGION
 
 echo "===================================="
 echo "creating AKS cluster: " $AKS_NAME
-az aks create -g $AKS_NAME -n $AKS_NAME --location $AKS_REGION --kubernetes-version $K8S_VERSION --node-vm-size Standard_DS2_v2 --node-count 1 --generate-ssh-keys --disable-rbac
+az aks create -g $AKS_NAME -n $AKS_NAME --location $AKS_REGION --node-vm-size Standard_DS2_v2 --node-count 1 --disable-rbac
+
+echo "merging the kubeconfig in ~/.kube/config"
+az aks get-credentials -g $AKS_NAME -n $AKS_NAME
 
 echo "===================================="
 echo "enabling Dev Spaces for AKS cluster: " $AKS_NAME


### PR DESCRIPTION
My new cluster's kubeconfig wasn't added to my ~/.kube/config so if I close the terminal and start a new one I can't access my cluster again. 

I added a fix to add the get-credentials aks command to merge the kubeconfig into the correct folder. 