### PR TITLE
Remove Users SQL DB unused authentication strings

### DIFF
--- a/Users/ConnectionConfig.json
+++ b/Users/ConnectionConfig.json
@@ -3,14 +3,10 @@
         "authentication": {
             "type": "default",
             "options": {
-                "userName": "dummyuser",
-                "password": "dummypassword"
             }
         },
-        "server": "dummydbserver",
         "options": {
             "encrypt": true,
-            "database": "dummydb",
             "useColumnNames": true,
             "debug": {
                 "data": true,

--- a/Users/server.js
+++ b/Users/server.js
@@ -17,10 +17,10 @@ app.use(bodyParser.json());
 var Request = require('tedious').Request;
 var TYPES = require('tedious').TYPES;
 var config = JSON.parse(fs.readFileSync('ConnectionConfig.json', 'utf8')).config;
-config.authentication.options.userName = process.env.SQL_USERNAME || config.authentication.options.userName;
-config.authentication.options.password = process.env.SQL_PASSWORD || config.authentication.options.password;
-config.server = process.env.SQL_SERVER || config.server;
-config.options.database = process.env.SQL_DATABASE || config.options.database;
+config.authentication.options.userName = process.env.SQL_USERNAME;
+config.authentication.options.password = process.env.SQL_PASSWORD;
+config.server = process.env.SQL_SERVER;
+config.options.database = process.env.SQL_DATABASE;
 var dbConnection = Connection.prototype;  // Will be initialized below
 
 var tableName = process.env.SQL_TABLE || 'Users'


### PR DESCRIPTION
According to my investigations:
* As of today, Mongo DB don't seem to be protected by any password, which looks weird but I can't find any sent when connecting.
* Users SQL DB is protected by the password defined in Databases\charts\databases\values.yaml.
* The values contained in file ConnectionConfig.json are always overwritten by what's defined in Users\charts\users\values.yaml, so I removed the useless data to reduce confusion.