### PR TITLE
Fix Bad Gateway after 'Launch Server (AZDS)' debugging ends

### DIFF
--- a/bikesharingweb/Dockerfile
+++ b/bikesharingweb/Dockerfile
@@ -6,6 +6,5 @@ WORKDIR /app
 COPY package.json .
 RUN npm install
 COPY . .
-RUN npm run build
 
 CMD ["npm", "start"]

--- a/bikesharingweb/package.json
+++ b/bikesharingweb/package.json
@@ -19,9 +19,8 @@
   },
   "scripts": {
     "dev": "nodemon server.js -w server.js -w server -w universal -w next.config.js -w config.js -w package.json",
-    "build": "next build",
     "export": "next export -o html",
-    "start": "NODE_ENV=production node server.js",
+    "start": "next build && NODE_ENV=production node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/823289

The issue was that, after a debugging session started through 'Launch Server (AZDS)', the Bike Sharing app was always returning Bad Gateway errors.
This is because the 'Launch Server (AZDS)' configuration triggers an 'azds up' with the '--on-exit-resume-up' option, which restarts the service once the debugging ends.
To do this, a script (https://devdiv.visualstudio.com/DevDiv/_git/Mindaro?path=%2Fsrc%2Fbuild%2Fscripts%2Frunbuild.sh&version=GBmaster) captures the CMD and ENTRYPOINT entries in the service's Dockerfile, and execute them on exit.

However, the bikesharingweb app relies on Next.js, which needs an extra build step, and this build step isn't captured by runbuild.sh. Running both commands in the start script ensure that the build is always executed before starting the server.