### PR TITLE
Reduce the memory requested by SQL database to avoid pod not scheduled

### DIFF
--- a/Databases/charts/databases/templates/sql.yaml
+++ b/Databases/charts/databases/templates/sql.yaml
@@ -29,5 +29,5 @@ spec:
         resources:
           requests:
             cpu: 400m
-            memory: 3Gi
+            memory: 2Gi
 {{ end }}


### PR DESCRIPTION
During the Bike Sharing getting started, we ask our users to create their clusters based on a VM that has 7GiB of memory available.
Based on that, Kubernetes surfaces 4.47GiB as allocatable memory for our node.
However, we defined our SQL database as requesting 3GiB to function properly. As you guess, this means that we have to make all the rest fit in the remaining space.

With the prod version of AZDS, everything fits even though we're close to the maximum (91%):
  CPU Requests  CPU Limits  Memory Requests  Memory Limits
  ------------  ----------  ---------------  -------------
  1078m (55%)   438m (22%)  4206Mi (91%)     984Mi (21%)

With the dev version of AZDS, because the new AZDS webhooks take an extra 400Mi, the total memory requested is higher than what is allocatable.
The impact of that is that the pod corresponding to the SQL database is never deployed, as our only node doesn't have enough room for it.

In practice, are able to get the Bike Sharing front end successfully, but every request to retrieve users fail (because users are stored... in the SQL database).

This fix decreases the amount of memory requested by the SQL database to 2GiB. This value corresponds to the one suggested as requirement for mssql-server-linux image: https://hub.docker.com/r/microsoft/mssql-server-linux/