### PR TITLE
Remove --kubernetes-version when creating cluster from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 1. Create a Kubernetes cluster in AKS:
 
     ```
-    az aks create -g bikesharinggroup -n bikesharingcluster --location eastus2 --kubernetes-version 1.12.5 --node-vm-size Standard_DS2_v2 --node-count 1 --generate-ssh-keys --disable-rbac
+    az aks create -g bikesharinggroup -n bikesharingcluster --location eastus2 --node-vm-size Standard_DS2_v2 --node-count 1 --generate-ssh-keys --disable-rbac
     ```
 
 1. Enable Azure Dev Spaces for the cluster we just created:


### PR DESCRIPTION
The version we currently suggest when creating the cluster (1.12.5) isn't supported anymore by AKS (or at least not in the region we suggest).
Here is the error our users get:
Operation failed with status: 'Bad Request'. Details: The value of parameter orchestratorProfile.OrchestratorVersion is invalid.

The doc written by Zach already removed this option, so we don't need to update it.