### PR TITLE
Prefixing the image tags with 'build.' so that it is parsed properly …

### DIFF
--- a/BikeSharingWeb/charts/bikesharingweb/values.yaml
+++ b/BikeSharingWeb/charts/bikesharingweb/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: bikesharingweb
 replicaCount: 1
 image:
   repository: azdspublic/bikesharing-bikesharingweb
-  tag: 20190416.4
+  tag: build.20190418.2
   pullPolicy: IfNotPresent
 imagePullSecrets: []
   # Optionally specify an array of imagePullSecrets.
@@ -30,7 +30,7 @@ ingress:
     kubernetes.io/ingress.class: addon-http-application-routing
   path: /
   hosts:
-    - dev.bikesharingweb.<REPLACE_ME_WITH_HOST_SUFFIX>
+    - dev.bikesharingweb.9dzcdlqvkp.eus.azds.io
   tls: []
     # - secretName: chart-example-tls
     #   hosts:

--- a/BikeSharingWeb/charts/bikesharingweb/values.yaml
+++ b/BikeSharingWeb/charts/bikesharingweb/values.yaml
@@ -30,7 +30,7 @@ ingress:
     kubernetes.io/ingress.class: addon-http-application-routing
   path: /
   hosts:
-    - dev.bikesharingweb.9dzcdlqvkp.eus.azds.io
+    - dev.bikesharingweb.<REPLACE_ME_WITH_HOST_SUFFIX>
   tls: []
     # - secretName: chart-example-tls
     #   hosts:

--- a/Bikes/charts/bikes/values.yaml
+++ b/Bikes/charts/bikes/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: bikes
 replicaCount: 1
 image:
   repository: azdspublic/bikesharing-bikes
-  tag: 20190416.2
+  tag: build.20190418.1
   pullPolicy: IfNotPresent
 imagePullSecrets: []
   # Optionally specify an array of imagePullSecrets.

--- a/Billing/charts/billing/values.yaml
+++ b/Billing/charts/billing/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: billing
 replicaCount: 1
 image:
   repository: azdspublic/bikesharing-billing
-  tag: 20190416.1
+  tag: build.20190418.1
   pullPolicy: IfNotPresent
 imagePullSecrets: []
   # Optionally specify an array of imagePullSecrets.

--- a/Gateway/charts/gateway/values.yaml
+++ b/Gateway/charts/gateway/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: gateway
 replicaCount: 1
 image:
   repository: azdspublic/bikesharing-gateway
-  tag: 20190416.1
+  tag: build.20190418.2
   pullPolicy: IfNotPresent
 imagePullSecrets: []
   # Optionally specify an array of imagePullSecrets.
@@ -27,7 +27,7 @@ ingress:
     kubernetes.io/ingress.class: addon-http-application-routing
   path: /
   hosts:
-  - dev.gateway.<REPLACE_ME_WITH_HOST_SUFFIX>
+  - dev.gateway.9dzcdlqvkp.eus.azds.io
   tls: []
     # - secretName: chart-example-tls
     #   hosts:

--- a/Gateway/charts/gateway/values.yaml
+++ b/Gateway/charts/gateway/values.yaml
@@ -27,7 +27,7 @@ ingress:
     kubernetes.io/ingress.class: addon-http-application-routing
   path: /
   hosts:
-  - dev.gateway.9dzcdlqvkp.eus.azds.io
+  - dev.gateway.<REPLACE_ME_WITH_HOST_SUFFIX>
   tls: []
     # - secretName: chart-example-tls
     #   hosts:

--- a/PopulateDatabase/charts/populatedatabase/values.yaml
+++ b/PopulateDatabase/charts/populatedatabase/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: populatedatabase
 replicaCount: 1
 image:
   repository: azdspublic/bikesharing-populatedatabase
-  tag: 20190416.1
+  tag: build.20190418.2
   pullPolicy: IfNotPresent
 imagePullSecrets: []
   # Optionally specify an array of imagePullSecrets.

--- a/Reservation/charts/reservation/values.yaml
+++ b/Reservation/charts/reservation/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: reservation
 replicaCount: 1
 image:
   repository: azdspublic/bikesharing-reservation
-  tag: 20190416.1
+  tag: build.20190418.1
   pullPolicy: IfNotPresent
 imagePullSecrets: []
   # Optionally specify an array of imagePullSecrets.

--- a/ReservationEngine/charts/reservationengine/values.yaml
+++ b/ReservationEngine/charts/reservationengine/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: reservationengine
 replicaCount: 1
 image:
   repository: azdspublic/bikesharing-reservationengine
-  tag: 20190416.1
+  tag: build.20190418.2
   pullPolicy: IfNotPresent
 imagePullSecrets: []
   # Optionally specify an array of imagePullSecrets.

--- a/Users/charts/users/values.yaml
+++ b/Users/charts/users/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: users
 replicaCount: 1
 image:
   repository: azdspublic/bikesharing-users
-  tag: 20190416.2
+  tag: build.20190418.1
   pullPolicy: IfNotPresent
 imagePullSecrets: []
   # Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
…as a string and not a float

When parsing the previous image tag (20190416.4), helm interpreted it as a float and use it to pull image in the scientific notation format... see https://github.com/helm/helm/issues/1707 for more details.